### PR TITLE
Fix for "Unable to cast object of type 'System.String' to type 'Syste…

### DIFF
--- a/src/API/LeadershipProfileAPI/Data/Models/StaffSearch.cs
+++ b/src/API/LeadershipProfileAPI/Data/Models/StaffSearch.cs
@@ -8,7 +8,7 @@
         public string MiddleName { get; set; }
         public string LastSurname { get; set; }
         public string FullName { get; set; }
-        public int YearsOfService { get; set; }
+        public decimal YearsOfService { get; set; }
         public string Certification { get; set; }
         public string Assignment { get; set; }
         public string Degree { get; set; }

--- a/src/API/LeadershipProfileAPI/Features/Search/List.cs
+++ b/src/API/LeadershipProfileAPI/Features/Search/List.cs
@@ -39,7 +39,7 @@ namespace LeadershipProfileAPI.Features.Search
             public string MiddleName { get; set; }
             public string LastSurName { get; set; }
             public string FullName { get; set; }
-            public int YearsOfService { get; set; }
+            public decimal YearsOfService { get; set; }
             public string Certification { get; set; }
             public string Assignment { get; set; }
             public string Degree { get; set; }


### PR DESCRIPTION
Fix for "Unable to cast object of type 'System.String' to type 'System.Decimal'."