### PR TITLE
Bug/fix advanced search not sorting or paging

### DIFF
--- a/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/AdvancedTableList.js
+++ b/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/AdvancedTableList.js
@@ -73,8 +73,8 @@ const CreateTableList = (props) => {
                     </tr>
                 </thead>
                 <tbody>
-                    {data !== [] ? data.map(profile => (
-                        <tr key={profile.id}>
+                    {data !== [] ? data.map((profile, index) => (
+                        <tr key={index}>
                             <td><span className="dot"></span></td>
                             <td>{profile.staffUniqueId}</td>
                             <td>{profile.lastSurName}, {profile.firstName}</td>

--- a/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/UseSearchDirectory.js
+++ b/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/UseSearchDirectory.js
@@ -81,7 +81,7 @@ function UseSearchDirectory() {
                 unmounted = true;
             };
         }
-    }, [filters]);
+    }, [filters, url]);
 
     function setPage(newPage) {
         setPaging({


### PR DESCRIPTION
The purpose of this PR is to fix sorting and paging currently not working for the advanced search. There was a missing listener to the URL changes as well as using `profile.id` as the `key` attribute for each result when `profile.id` was `null`; not available in this context.