### PR TITLE
Cleanup card layout and refactor pagination details

### DIFF
--- a/src/Web/src/App.css
+++ b/src/Web/src/App.css
@@ -202,6 +202,7 @@
 
 .pagination-button-div a {
   padding: 5px;
+  cursor: pointer;
 }
 
 .pagination-arrows {
@@ -366,11 +367,6 @@
   font-size: small;
 }
 
-/* Card Profile */
-.card-spacing{
-  margin-bottom: 30px;
-}
-
 /* Advanced Search filter box */
 .advanced-filters-container{
   border-radius: 4px;
@@ -402,4 +398,75 @@ h5{
 
 .date-picker-sm{
   font-size: 12px !important;
+}
+
+/* Card Profile */
+.card-layout {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(240px, 1fr));
+  grid-gap: 50px;
+}
+
+.card-pagination-grid {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.card-grid {
+  display: grid;
+  box-shadow: 0 2px 4px;
+  grid-template-columns: repeat(12, 1fr);
+  grid-template-rows: repeat(5, 1fr);
+}
+
+.card-grid img {
+  padding-right: 10px;
+}
+
+.card-content {
+  width: 300px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card-profile {
+  margin-top: 20px;
+  grid-column: 2 / span 3;
+  grid-row: 1 / span 3;
+}
+
+.card-link {
+  margin-top: 20px;
+  grid-column: 12 / span 1;
+  grid-row: 1 / span 1;
+}
+
+
+.card-contact {
+  margin-top: 20px;
+  grid-column: 4 / span 8;
+  grid-row: 1 / span 3;
+}
+
+.card-seperator {
+  grid-column: 4 / span 8;
+  grid-row: 4;
+}
+
+.divider {
+  border-bottom: 1px solid rgb(116, 116, 116);
+  height: 2px;
+  margin: 0.5em 0px 1.5em;
+}
+
+.card-person {
+  grid-column: 4 / span 4;
+  grid-row: 5;
+}
+
+.card-geo {
+  grid-column: 8 / span 4;
+  grid-row: 5;
 }

--- a/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/AdvancedTableList.js
+++ b/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/AdvancedTableList.js
@@ -92,7 +92,7 @@ const CreateTableList = (props) => {
                         </tr>)) : ''}
                         <tr className="bottom-row">
                             <td colSpan="11">
-                                <PaginationDetails paging={paging} />
+                                <PaginationDetails paging={paging} count={data?.length} />
                             </td>
                             <td colSpan="2" className="pagination-buttons-container">
                                 <PaginationButtons paging={paging} setPage={setPage} />

--- a/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/AdvancedTableList.js
+++ b/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/AdvancedTableList.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { RightPointingIcon } from '../../Icons';
 import Sorting from '../Sorting';
 import PaginationButtons from '../PaginationButtons';
+import PaginationDetails from '../PaginationDetails'
 
 const CreateTableList = (props) => {
     const { sort, data, setColumnSort, paging, setPage } = props;
@@ -91,7 +92,7 @@ const CreateTableList = (props) => {
                         </tr>)) : ''}
                         <tr className="bottom-row">
                             <td colSpan="11">
-                                <span>Showing {paging.page}-10 of {paging.totalSize} Users</span>
+                                <PaginationDetails paging={paging} />
                             </td>
                             <td colSpan="2" className="pagination-buttons-container">
                                 <PaginationButtons paging={paging} setPage={setPage} />

--- a/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/SearchDirectory.js
+++ b/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/SearchDirectory.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { TableViewIcon, CardViewIcon } from '../../Icons';
 import BreadcrumbList from '../../Breadcrumb';
 import AdvancedTableList from './AdvancedTableList';
 import CardList from './../CardListComponents/CardList';
@@ -29,7 +28,7 @@ const SearchDirectory = () => {
             { activeComponent === "table" ? (
                 <AdvancedTableList sort={sort} data={data} setColumnSort={setColumnSort} paging={paging} setPage={setPage} />
             ) : activeComponent === "card" ? (
-                <CardList data={data}/>
+                <CardList data={data} paging={paging} setPage={setPage} />
             ) : null (
                 <div />
             )}

--- a/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/UseSearchDirectory.js
+++ b/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/UseSearchDirectory.js
@@ -59,9 +59,7 @@ function UseSearchDirectory() {
             fetch(apiUrl, API_CONFIG('POST', JSON.stringify(filters)))
                 .then(response => response.json())
                 .then((response) => {
-                if (response.isError) {
-                    setError(true);
-                }
+                setError(response.isError);
                 if (!unmounted && response !== null) {
                     if (response.results !== undefined) {
                         setData(response.results);

--- a/src/Web/src/components/DirectoryComponents/CardListComponents/CardList.js
+++ b/src/Web/src/components/DirectoryComponents/CardListComponents/CardList.js
@@ -1,26 +1,28 @@
-import React from 'react';
-import { MailIcon, PhoneIcon, PersonIcon, GeoIcon, RightPointingIcon } from '../../Icons';
-import { Card, CardTitle, CardText, Row, Col } from 'reactstrap';
-import CardProfile from './CardProfile';
+import React from "react";
+import CardProfile from "./CardProfile";
+import PaginationDetails from "../PaginationDetails";
+import PaginationButtons from "../PaginationButtons";
 
 const CardList = (props) => {
-    
-    const {data} = props;
-    return (
+  const { data, paging, setPage } = props;
+
+  return (
+    <>
+      <div class="card-layout">
+        {data.map((profile, index) => {
+          return <CardProfile key={index} data={profile}></CardProfile>;
+        })}
+      </div>
+      <div class="card-pagination-grid">
         <div>
-            {
-                <Row key="1" className="col-md-12">
-                    { 
-                    data.map((profile, index) =>{
-                        return(
-                            <CardProfile data={profile}></CardProfile>
-                        );
-                    })
-                }
-                </Row>               
-            }
+          <PaginationDetails paging={paging} />
         </div>
-    );
-}
+        <td className="pagination-buttons-container">
+          <PaginationButtons paging={paging} setPage={setPage} />
+        </td>
+      </div>
+    </>
+  );
+};
 
 export default CardList;

--- a/src/Web/src/components/DirectoryComponents/CardListComponents/CardList.js
+++ b/src/Web/src/components/DirectoryComponents/CardListComponents/CardList.js
@@ -17,9 +17,9 @@ const CardList = (props) => {
         <div>
           <PaginationDetails paging={paging} count={data?.length} />
         </div>
-        <td className="pagination-buttons-container">
+        <div className="pagination-buttons-container">
           <PaginationButtons paging={paging} setPage={setPage} />
-        </td>
+        </div>
       </div>
     </>
   );

--- a/src/Web/src/components/DirectoryComponents/CardListComponents/CardList.js
+++ b/src/Web/src/components/DirectoryComponents/CardListComponents/CardList.js
@@ -15,7 +15,7 @@ const CardList = (props) => {
       </div>
       <div class="card-pagination-grid">
         <div>
-          <PaginationDetails paging={paging} />
+          <PaginationDetails paging={paging} count={data?.length} />
         </div>
         <td className="pagination-buttons-container">
           <PaginationButtons paging={paging} setPage={setPage} />

--- a/src/Web/src/components/DirectoryComponents/CardListComponents/CardList.js
+++ b/src/Web/src/components/DirectoryComponents/CardListComponents/CardList.js
@@ -8,12 +8,12 @@ const CardList = (props) => {
 
   return (
     <>
-      <div class="card-layout">
+      <div className="card-layout">
         {data.map((profile, index) => {
           return <CardProfile key={index} data={profile}></CardProfile>;
         })}
       </div>
-      <div class="card-pagination-grid">
+      <div className="card-pagination-grid">
         <div>
           <PaginationDetails paging={paging} count={data?.length} />
         </div>

--- a/src/Web/src/components/DirectoryComponents/CardListComponents/CardProfile.js
+++ b/src/Web/src/components/DirectoryComponents/CardListComponents/CardProfile.js
@@ -7,25 +7,25 @@ const CardProfile = (props) => {
     const {data} = props;
 
     return(
-        <div class="card-grid">
-            <div class="card-profile">
+        <div className="card-grid">
+            <div className="card-profile">
                 <DefaultProfile></DefaultProfile>
             </div>
-            <div class="card-link">
+            <div className="card-link">
                 <Link to={`profile/${data.staffUniqueId}`}><RightPointingIcon /></Link>
             </div>
-            <div class="card-contact">
-                <h4 class="card-content">{data.fullName}</h4>
-                <div class="card-content"><MailIcon />{data.email}</div>
-                <div class="card-content"><PhoneIcon />{data.telePhone}</div>
+            <div className="card-contact">
+                <h4 className="card-content">{data.fullName}</h4>
+                <div className="card-content"><MailIcon />{data.email}</div>
+                <div className="card-content"><PhoneIcon />{data.telePhone}</div>
             </div>
-            <div class="card-seperator divider">
+            <div className="card-seperator divider">
             </div>
-            <div class="card-person">
-                <div class="card-content"><PersonIcon />{data.highestDegree}</div>
+            <div className="card-person">
+                <div className="card-content"><PersonIcon />{data.highestDegree}</div>
             </div>
-            <div class="card-geo">
-                <div class="card-content"><GeoIcon />{data.location}</div>
+            <div className="card-geo">
+                <div className="card-content"><GeoIcon />{data.location}</div>
             </div>
         </div>
     )

--- a/src/Web/src/components/DirectoryComponents/CardListComponents/CardProfile.js
+++ b/src/Web/src/components/DirectoryComponents/CardListComponents/CardProfile.js
@@ -1,37 +1,32 @@
 import React from 'react';
 import { MailIcon, PhoneIcon, PersonIcon, GeoIcon, RightPointingIcon } from '../../Icons';
-import { Card, CardTitle, CardText, Row, Col } from 'reactstrap';
+import { Link } from 'react-router-dom';
 import { DefaultProfile } from '../../images'
-
 const CardProfile = (props) => {
 
     const {data} = props;
 
     return(
-        <div className="col-md-4 col-sm-4 card-spacing">
-            <Card>
-                <Row sm="3">
-                    <Col sm="2">
-                        <DefaultProfile></DefaultProfile>
-                    </Col>
-                    <Col sm="9">
-                        <CardTitle tag="h5">{data.fullName}</CardTitle>
-                        <CardText><MailIcon />{data.email}</CardText>
-                        <CardText><PhoneIcon />{data.telePhone}</CardText>
-                    </Col>
-                    <Col sm="1">
-                        <RightPointingIcon />
-                    </Col>
-                </Row>
-                <Row>
-                    <Col sm={{ size:3, offset:2}}>
-                        <CardText><PersonIcon />{data.highestDegree}</CardText>
-                    </Col>
-                    <Col>
-                        <CardText><GeoIcon />{data.location}</CardText>
-                    </Col>
-                </Row>
-            </Card>
+        <div class="card-grid">
+            <div class="card-profile">
+                <DefaultProfile></DefaultProfile>
+            </div>
+            <div class="card-link">
+                <Link to={`profile/${data.staffUniqueId}`}><RightPointingIcon /></Link>
+            </div>
+            <div class="card-contact">
+                <h4 class="card-content">{data.fullName}</h4>
+                <div class="card-content"><MailIcon />{data.email}</div>
+                <div class="card-content"><PhoneIcon />{data.telePhone}</div>
+            </div>
+            <div class="card-seperator divider">
+            </div>
+            <div class="card-person">
+                <div class="card-content"><PersonIcon />{data.highestDegree}</div>
+            </div>
+            <div class="card-geo">
+                <div class="card-content"><GeoIcon />{data.location}</div>
+            </div>
         </div>
     )
 }

--- a/src/Web/src/components/DirectoryComponents/Directory.js
+++ b/src/Web/src/components/DirectoryComponents/Directory.js
@@ -39,7 +39,7 @@ const Directory = () => {
             { activeComponent === "table" ? (
                 <TableList sort={sort} data={data} setColumnSort={setColumnSort} paging={paging} setPage={setPage} />
             ) : activeComponent === "card" ? (
-                <CardList data={data} />
+                <CardList data={data} paging={paging} setPage={setPage} />
             ) : null (
                 <div />
             )}

--- a/src/Web/src/components/DirectoryComponents/PaginationButtons.js
+++ b/src/Web/src/components/DirectoryComponents/PaginationButtons.js
@@ -3,8 +3,13 @@ import PropTypes from 'prop-types';
 
 const PaginationButtons = (props) => {
   const { paging, setPage } = props;
-  const { page, maxPages } = paging;
+  const { page, maxPages, totalSize } = paging;
   const intPage = parseInt(page, 0);
+
+  if (totalSize == 0) {
+    return (<div></div>)
+  }
+
   return (
     <div className="pagination-button-div">
       {/* eslint-disable */}

--- a/src/Web/src/components/DirectoryComponents/PaginationDetails.js
+++ b/src/Web/src/components/DirectoryComponents/PaginationDetails.js
@@ -1,17 +1,23 @@
 import React from "react";
 
 const PaginationDetails = (props) => {
-  const { paging } = props;
+  const { paging, count } = props;
   const { page, totalSize } = paging;
 
   if (totalSize == "0") {
     return (<div></div>);
   }
 
+  if (!count || count === 0){
+    return (
+      <span>No Results</span>
+    );
+  }
+
   return (
     <span>
       Showing {page == 1 ? 1 : (page - 1) * 10 + 1}-
-      {(page - 1) * 10 + 10} of {totalSize} Users
+      {(page - 1) * 10 + count} of {totalSize} Users
     </span>
   );
 };

--- a/src/Web/src/components/DirectoryComponents/PaginationDetails.js
+++ b/src/Web/src/components/DirectoryComponents/PaginationDetails.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+const PaginationDetails = (props) => {
+  const { paging } = props;
+  const { page, totalSize } = paging;
+
+  if (totalSize == "0") {
+    return (<div></div>);
+  }
+
+  return (
+    <span>
+      Showing {page == 1 ? 1 : (page - 1) * 10 + 1}-
+      {(page - 1) * 10 + 10} of {totalSize} Users
+    </span>
+  );
+};
+
+export default PaginationDetails;

--- a/src/Web/src/components/DirectoryComponents/TableList.js
+++ b/src/Web/src/components/DirectoryComponents/TableList.js
@@ -74,7 +74,7 @@ const CreateTableList = (props) => {
                         </tr>)) : ''}
                         <tr className="bottom-row">
                             <td colSpan="8">
-                                <PaginationDetails paging={paging} />
+                                <PaginationDetails paging={paging} count={data?.length} />
                             </td>
                             <td colSpan="2" className="pagination-buttons-container">
                                 <PaginationButtons paging={paging} setPage={setPage} />

--- a/src/Web/src/components/DirectoryComponents/TableList.js
+++ b/src/Web/src/components/DirectoryComponents/TableList.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { RightPointingIcon } from '../Icons';
 import Sorting from './Sorting';
 import PaginationButtons from './PaginationButtons';
+import PaginationDetails from "./PaginationDetails"
 
 const CreateTableList = (props) => {
     const { sort, data, setColumnSort, paging, setPage } = props;
@@ -73,7 +74,7 @@ const CreateTableList = (props) => {
                         </tr>)) : ''}
                         <tr className="bottom-row">
                             <td colSpan="8">
-                                <span>Showing {paging.page}-10 of {paging.totalSize} Users</span>
+                                <PaginationDetails paging={paging} />
                             </td>
                             <td colSpan="2" className="pagination-buttons-container">
                                 <PaginationButtons paging={paging} setPage={setPage} />

--- a/src/Web/src/components/RoleMangementComponents/RoleManagement.js
+++ b/src/Web/src/components/RoleMangementComponents/RoleManagement.js
@@ -3,6 +3,7 @@ import { Table, Button, Form, FormGroup, Input, Alert } from 'reactstrap';
 import PaginationButtons from '../DirectoryComponents/PaginationButtons';
 import UseRoleManagement from './UseRoleManagement';
 import BreadcrumbList from '../Breadcrumb';
+import PaginationDetails from '../DirectoryComponents/PaginationDetails'
 
 const RoleManagement = () => {
     const { data, paging, SetPage, OnSubmit, error, bind } = UseRoleManagement();
@@ -51,7 +52,7 @@ const RoleManagement = () => {
                                 <Button onClick={event => OnSubmit(event)}>Save</Button>
                             </td> */}
                             <td colSpan="4">
-                                <span>Showing {paging.page}-10 of {paging.totalSize} Users</span>
+                                <PaginationDetails paging={paging} />
                             </td>
                             <td colSpan="1" className="pagination-buttons-container">
                                 <PaginationButtons paging={paging} setPage={SetPage} />

--- a/src/Web/src/components/RoleMangementComponents/RoleManagement.js
+++ b/src/Web/src/components/RoleMangementComponents/RoleManagement.js
@@ -52,7 +52,7 @@ const RoleManagement = () => {
                                 <Button onClick={event => OnSubmit(event)}>Save</Button>
                             </td> */}
                             <td colSpan="4">
-                                <PaginationDetails paging={paging} />
+                                <PaginationDetails paging={paging} count={data?.length} />
                             </td>
                             <td colSpan="1" className="pagination-buttons-container">
                                 <PaginationButtons paging={paging} setPage={SetPage} />


### PR DESCRIPTION
Switched the card layout to use grid to best replicate the design [from here](https://docs.google.com/presentation/d/1UJQp4xYmSSxbvmDPKVrR8egwkqk-dg_G3GBOrGAuWE0/edit#slide=id.gae809781d2_0_36).  After applying the new style it was lacking the pagination details and buttons to query for more users so that was added to the components/DirectoryComponents/CardListComponents/CardList.js.

There was also an issue where if the search encountered an error it would display displayed, "Error - Unable to load data” and even after a subsequent successful query the error message isn’t removed. I got around that by calling the error setter with the value of the response.isError after each request in components/DirectoryComponents/AdvancedSearchComponent/UseSearchDirectory.js.