### PR TITLE
Remove the search UI from Directory page

### DIFF
--- a/src/Web/src/components/DirectoryComponents/Directory.js
+++ b/src/Web/src/components/DirectoryComponents/Directory.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { TableViewIcon, CardViewIcon } from '../Icons';
 import BreadcrumbList from '../Breadcrumb';
-import DirectoryFilters from './DirectoryFilters';
 import TableList from './TableList';
 import CardList from './CardListComponents/CardList';
 import UseDirectory from './UseDirectory';
@@ -33,7 +32,6 @@ const Directory = () => {
                     </div>
                 </div>
             </div>
-            <DirectoryFilters search={search} setSearchValue={setSearchValue} />
             
             { error ? <ErrorMessage /> : '' }
             { activeComponent === "table" ? (


### PR DESCRIPTION
Removed the search/filter UI from the Directory page as it is available on the Advanced Search page.