### PR TITLE
Remove hard-coded API url

### DIFF
--- a/src/Web/src/components/DataCorrectionComponent/UseDataCorrectionModal.js
+++ b/src/Web/src/components/DataCorrectionComponent/UseDataCorrectionModal.js
@@ -36,7 +36,7 @@ function UseDataCorrectionModal() {
         feedbackInfo["StaffEmail"] = data.email;
         feedbackInfo["Telephone"] = data.phone;
 
-        const apiUrl = new URL(API_URL.href + '/profile/datacorrection');
+        const apiUrl = new URL(API_URL + 'profile/datacorrection');
         fetch(apiUrl, API_CONFIG('POST', JSON.stringify(feedbackInfo)))
         .then((response) => {
             unmounted = true;

--- a/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/UseAdvancedSearch.js
+++ b/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/UseAdvancedSearch.js
@@ -13,7 +13,7 @@ function UseAdvancedSearch(){
 
     async function GetDegrees(){
         let unmounted = false;
-        const apiUrl = new URL(API_URL.href + `/webcontrols/dropdownlist/degrees`);
+        const apiUrl = new URL(API_URL + `webcontrols/dropdownlist/degrees`);
         fetch(apiUrl, API_CONFIG('GET')
         ).then(response => response.json())
         .then((response) => {
@@ -47,7 +47,7 @@ function UseAdvancedSearch(){
 
     async function GetPositionHistory(){
         let unmounted = false;
-        const apiUrl = new URL(API_URL.href + `/webcontrols/dropdownlist/assignments`);
+        const apiUrl = new URL(API_URL + `webcontrols/dropdownlist/assignments`);
         fetch(apiUrl, API_CONFIG('GET')
         ).then(response => response.json())
         .then((response) => {
@@ -72,7 +72,7 @@ function UseAdvancedSearch(){
 
     async function GetCertifications(){
         let unmounted = false;
-        const apiUrl = new URL(API_URL.href + `/webcontrols/dropdownlist/certifications`);
+        const apiUrl = new URL(API_URL + `webcontrols/dropdownlist/certifications`);
         fetch(apiUrl, API_CONFIG('GET')
         ).then(response => response.json())
         .then((response) => {
@@ -97,7 +97,7 @@ function UseAdvancedSearch(){
 
     async function GetCatergories(){
         let unmounted = false;
-        const apiUrl = new URL(API_URL.href + `/webcontrols/dropdownlist/measurementcategories`);
+        const apiUrl = new URL(API_URL + `webcontrols/dropdownlist/measurementcategories`);
         fetch(apiUrl, API_CONFIG('GET')
         ).then(response => response.json())
         .then((response) => {
@@ -125,7 +125,7 @@ function UseAdvancedSearch(){
 
     function GetSubCategories(categorieId){
         let unmounted = false;
-        const apiUrl = new URL(API_URL.href + `/webcontrols/dropdownlist/measurementsubcategories`);
+        const apiUrl = new URL(API_URL + `webcontrols/dropdownlist/measurementsubcategories`);
         fetch(apiUrl, API_CONFIG('GET')
         ).then(response => response.json())
         .then((response) => {

--- a/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/UseSearchDirectory.js
+++ b/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/UseSearchDirectory.js
@@ -57,7 +57,7 @@ function UseSearchDirectory() {
         if(filters !== undefined){
             if (!searchableUrl.current.search) return;
             let unmounted = false;
-            const apiUrl = new URL(API_URL.href + `/search${history.location.search}`);
+            const apiUrl = new URL(API_URL + `search${history.location.search}`);
             fetch(apiUrl, API_CONFIG('POST', JSON.stringify(filters)))
             .then((response) => {
                 if (!response.ok) {

--- a/src/Web/src/components/DirectoryComponents/UseDirectory.js
+++ b/src/Web/src/components/DirectoryComponents/UseDirectory.js
@@ -55,7 +55,7 @@ function UseDirectory() {
     useEffect(() => {
         if (!searchableUrl.current.search) return;
         let unmounted = false;
-        const apiUrl = new URL(API_URL.href + `/profile${history.location.search}`);
+        const apiUrl = new URL(API_URL + `profile${history.location.search}`);
         fetch(apiUrl, API_CONFIG('GET'))
         .then((response) => {
             if (!response.ok) {

--- a/src/Web/src/components/LoginComponents/UseForgotPassword.js
+++ b/src/Web/src/components/LoginComponents/UseForgotPassword.js
@@ -28,7 +28,7 @@ function UseForgotPassword() {
 
     function setForgotPassword(e) {
         if (staffUniqueId !== '' && userName !== '') {
-            const apiUrl = new URL(API_URL.href + '/account/forgotPassword');
+            const apiUrl = new URL(API_URL + 'account/forgotPassword');
 
             fetch(apiUrl, API_CONFIG(
                     'POST', JSON.stringify({

--- a/src/Web/src/components/LoginComponents/UseLogin.js
+++ b/src/Web/src/components/LoginComponents/UseLogin.js
@@ -35,7 +35,7 @@ function UseLogin() {
         if (password !== '' && username !== '') {
 
             let unmounted = false;
-            const apiUrl = new URL(API_URL.href + '/account/login');
+            const apiUrl = new URL(API_URL + 'account/login');
 
             fetch(apiUrl, API_CONFIG(
                 'POST', 

--- a/src/Web/src/components/LoginComponents/UseRegistration.js
+++ b/src/Web/src/components/LoginComponents/UseRegistration.js
@@ -47,7 +47,7 @@ function UseRegistration() {
 
     async function setRegistration() {
         let unmounted = false;
-        const apiUrl = new URL(API_URL.href + '/account/register');
+        const apiUrl = new URL(API_URL + 'account/register');
         fetch(apiUrl, API_CONFIG("POST", JSON.stringify(registrationInfo))
         ).then((response) => {
             if (!unmounted && response.status === 200) {

--- a/src/Web/src/components/LoginComponents/UseResetPassword.js
+++ b/src/Web/src/components/LoginComponents/UseResetPassword.js
@@ -53,7 +53,7 @@ function UseResetPassword() {
 
     function setResetPassword(e) {
         if (newPassword !== '' && confirmPassword !== '') {
-            const apiUrl = new URL(API_URL.href + '/account/resetPassword');
+            const apiUrl = new URL(API_URL + 'account/resetPassword');
 
             fetch(apiUrl, API_CONFIG(
                     'POST', JSON.stringify({

--- a/src/Web/src/components/ProfileComponents/UseProfile.js
+++ b/src/Web/src/components/ProfileComponents/UseProfile.js
@@ -90,7 +90,7 @@ function UseProfile(id) {
     useEffect(() => {
         let unmounted = false;
 
-        const apiUrl = new URL(API_URL.href + `/profile/${id}`);
+        const apiUrl = new URL(API_URL + `profile/${id}`);
         fetch(apiUrl, API_CONFIG('GET')
         ).then(response => response.json())
         .then((response) => {

--- a/src/Web/src/components/RoleMangementComponents/UseRoleManagement.js
+++ b/src/Web/src/components/RoleMangementComponents/UseRoleManagement.js
@@ -48,7 +48,7 @@ function UseRoleManagement() {
 
     useEffect(() => {
         let unmounted = false;
-        const apiUrl = new URL(API_URL.href + '/userclaims?page=' + paging.page);
+        const apiUrl = new URL(API_URL + 'userclaims?page=' + paging.page);
         fetch(apiUrl, API_CONFIG('GET'))
             .then(response => response.json())
             .then((response) => {
@@ -138,7 +138,7 @@ function UseRoleManagement() {
      
     function AddAdminRoles(addList) {
         let unmounted = false;
-        const apiUrl = new URL(API_URL.href + '/userclaims');
+        const apiUrl = new URL(API_URL + 'userclaims');
         fetch(apiUrl, API_CONFIG('POST', JSON.stringify({staffUniqueIds: addList, claimType: "role", claimValue: "Admin"})))
             .then(() => Promise.resolve())
             .catch((error) => {
@@ -152,7 +152,7 @@ function UseRoleManagement() {
 
     function RemoveAdminRoles(removeList) {
         let unmounted = false;
-        const apiUrl = new URL(API_URL.href + '/userclaims');
+        const apiUrl = new URL(API_URL + 'userclaims');
         fetch(apiUrl, API_CONFIG('DELETE', JSON.stringify({staffUniqueIds: removeList, claimType: "role", claimValue: "Admin"})))
             .then(() => Promise.resolve())
             .catch((error) => {

--- a/src/Web/src/config.js
+++ b/src/Web/src/config.js
@@ -1,5 +1,6 @@
 function config() {
-    const API_URL = process.env.NODE_ENV !== 'production' ? new URL('https://localhost:5100/api') : new URL('https://localhost:5100/api');
+    var getUrl = window.location;
+    const API_URL = process.env.NODE_ENV === 'production' ? new URL(`${getUrl.protocol}//${getUrl.host}/api/`) : new URL('https://localhost:5100/api/');
     const API_CONFIG = (method, body=null) => { 
         return {
             method: method,

--- a/src/Web/src/config.js
+++ b/src/Web/src/config.js
@@ -1,6 +1,6 @@
 function config() {
     var getUrl = window.location;
-    const API_URL = process.env.NODE_ENV === 'production' ? new URL(`${getUrl.protocol}//${getUrl.host}/api/`) : new URL('https://localhost:5100/api/');
+    const API_URL = process.env.NODE_ENV === 'production' ? new URL(`${getUrl.protocol}//${getUrl.host}/api/`) : new URL('https://localhost:5100/');
     const API_CONFIG = (method, body=null) => { 
         return {
             method: method,

--- a/src/Web/src/utils/logout-service.js
+++ b/src/Web/src/utils/logout-service.js
@@ -9,7 +9,7 @@ function LogoutService() {
     const { API_URL } = config();
 
     function logout() {
-        const apiUrl = new URL(API_URL.href + '/account/logout');
+        const apiUrl = new URL(API_URL + 'account/logout');
         fetch(apiUrl, {
             method: 'POST',
             mode: 'cors',


### PR DESCRIPTION
The hard-coded API URL prevents the app from being access from a machine other than localhost. By using the window.location it can piece together the current URL based on the windows address.  Open to suggestions on a better way to do this in a post build scenario. 

Also removed the extra leading slash from the constructed URL's.