### PR TITLE
Make Timeout Adjustable

### DIFF
--- a/src/API/LeadershipProfileAPI/Properties/launchSettings.json
+++ b/src/API/LeadershipProfileAPI/Properties/launchSettings.json
@@ -26,7 +26,8 @@
         "AuthorityServer": "https://localhost:5100",
         "WebClient": "http://localhost",
         "WebClientRedirectUri": "/account/login",
-        "ForgotPasswordTokenLifeSpanHours": "7"
+        "ForgotPasswordTokenLifeSpanHours": "7",
+        "ValidTokenLifeSpanHours": ".5"
       },
       "dotnetRunMessages": "true",
       "applicationUrl": "https://localhost:5100;http://localhost:5000"

--- a/src/API/LeadershipProfileAPI/Startup.cs
+++ b/src/API/LeadershipProfileAPI/Startup.cs
@@ -152,6 +152,10 @@ namespace LeadershipProfileAPI
                 opt.TokenLifespan = TimeSpan.FromHours(Convert.ToDouble(Environment.GetEnvironmentVariable("ForgotPasswordTokenLifeSpanHours")))
             );
 
+            services.Configure<SecurityStampValidatorOptions>(opt =>
+                opt.ValidationInterval = TimeSpan.FromHours(Convert.ToDouble(Environment.GetEnvironmentVariable("ValidTokenLifeSpanHours")))
+            );
+
             services.ConfigureApplicationCookie(options =>
             {
                 options.Events.OnRedirectToAccessDenied =


### PR DESCRIPTION
This allows the asp identity timeout to be configurable per environment it is deployed to.