### PR TITLE
Use Octopus-friendly parameter for password reset url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -592,3 +592,4 @@ yarn-debug.log*
 yarn-error.log*
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudio,rider,react,visualstudiocode,node
+**/.idea/

--- a/src/API/LeadershipProfileAPI/appsettings.json
+++ b/src/API/LeadershipProfileAPI/appsettings.json
@@ -16,6 +16,6 @@
     "AdminEmail": "cgreene@kleinisd.net"
   },
   "ApplicationConfiguration": {
-    "ResetPasswordBaseUrl": "http://localhost:80"
+    "ResetPasswordBaseUrl": "#{ResetPasswordBaseUrl}"
   }
 }


### PR DESCRIPTION
When deploying Octopus needs a variable in the patter of #{var} so that it can replace it with a process value. Also adjusted the scope of the .ignore for jetbrains files to be beyond root.