### PR TITLE
Fix API Subcategories

### DIFF
--- a/src/API/DatabaseMigrations/scripts/views/vw_ListAllCategoriesSubCategories.sql
+++ b/src/API/DatabaseMigrations/scripts/views/vw_ListAllCategoriesSubCategories.sql
@@ -1,0 +1,16 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE   VIEW [edfi].[vw_ListAllCategoriesSubCategories] AS
+
+select distinct
+     pm.TpdmRubricTypeDescriptorId as CategoryId
+    ,d.CodeValue as Category
+    ,pm.TpdmRubricTitle as [SubCategory]
+from extension.PerformanceMeasure as pm
+left join extension.RubricTypeDescriptor as rtd on rtd.RubricTypeDescriptorID = pm.TpdmRubricTypeDescriptorId
+left join edfi.Descriptor as d on d.DescriptorId = rtd.RubricTypeDescriptorId
+
+GO

--- a/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/MeasurementSubCategories/Get.cs
+++ b/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/MeasurementSubCategories/Get.cs
@@ -10,9 +10,12 @@ using Microsoft.EntityFrameworkCore;
 
 namespace LeadershipProfileAPI.Controllers.WebControls.DropDownList.MeasurementSubCategories
 {
-    public static class List
+    public static class Get
     {
-        public class Query : IRequest<Response> { }
+        public class Query : IRequest<Response>         
+        {
+            public int Id { get; set; }
+        }
 
         public class Response
         {
@@ -39,7 +42,8 @@ namespace LeadershipProfileAPI.Controllers.WebControls.DropDownList.MeasurementS
 
             public async Task<Response> Handle(Query request, CancellationToken cancellationToken)
             {
-                var list = await _dbContext.ListItemCategories
+                var list = await _dbContext.ListItemSubCategories
+                    .Where(x => x.CategoryId == request.Id)
                     .ProjectTo<SubCategoryItem>(_mapper.ConfigurationProvider)
                     .ToListAsync(cancellationToken);
 

--- a/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/MeasurementSubCategories/MappingProfile.cs
+++ b/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/MeasurementSubCategories/MappingProfile.cs
@@ -6,7 +6,8 @@ namespace LeadershipProfileAPI.Controllers.WebControls.DropDownList.MeasurementS
     {
         public MappingProfile()
         {
-            CreateMap<ListItemSubCategory, List.SubCategory>();
+            CreateMap<ListItemSubCategory, List.SubCategoryItem>();
+            CreateMap<ListItemSubCategory, Get.SubCategoryItem>();
         }
     }
 }

--- a/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/MeasurementSubCategories/MeasurementCategoryController.cs
+++ b/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/MeasurementSubCategories/MeasurementCategoryController.cs
@@ -29,5 +29,12 @@ namespace LeadershipProfileAPI.Controllers.WebControls.DropDownList.MeasurementS
             var result = await _mediator.Send(query, cancellationToken);
             return Ok(result);
         }
+        
+        [HttpGet("{id:int}")]
+        public async Task<ActionResult> GetAsync([FromRoute] int id, CancellationToken cancellationToken)
+        {
+            var result = await _mediator.Send(new Get.Query { Id = id }, cancellationToken);
+            return Ok(result);
+        }
     }
 }

--- a/src/API/LeadershipProfileAPI/Data/EdFiDbContext.cs
+++ b/src/API/LeadershipProfileAPI/Data/EdFiDbContext.cs
@@ -48,7 +48,7 @@ namespace LeadershipProfileAPI.Data
                 .HasNoKey();
 
             modelBuilder.Entity<ListItemSubCategory>()
-                .ToView("vw_ListAllSubCategories", "edfi")
+                .ToView("vw_ListAllCategoriesSubCategories", "edfi")
                 .HasNoKey();
 
             modelBuilder.Entity<Staff>().ToTable("Staff", schema: "edfi")

--- a/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
+++ b/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
@@ -317,7 +317,7 @@ namespace LeadershipProfileAPI.Data
 
                     ,ru.MeasureCategory as RatingCategory
                     ,mr.SubCategory as RatingSubCategory
-                    ,cast(coalesce(pm.Score, 0.0) as decimal(5,2)) as Rating
+                    ,coalesce(cast(pm.Score as decimal(5,2)), 0.0) as Rating
 
                 from edfi.Staff as s
                 left join staffService on staffService.StaffUSI = s.StaffUSI
@@ -414,7 +414,13 @@ namespace LeadershipProfileAPI.Data
             if (ratings != null && ratings.Score > 0)
             {
                 // Provide the condition being searched for matching your schema. Examples: "(r.Rating = 3)" or "(r.Rating = 3 and r.RatingCateogryId = 45)"
-                return $"({(ratings.CategoryId > 0 ? $"mr.Category = {ratings.CategoryId}" : "")}{(ratings.CategoryId > 0 && ratings.Score > 0 ? " and " : "")}{(ratings.Score > 0 ? $"pm.Score = {ratings.Score}" : "")})";
+                var whereCategory = ratings.CategoryId > 0 ? $"mr.Category = {ratings.CategoryId}" : string.Empty;
+                var andCatAndScore = ratings.CategoryId > 0 && ratings.Score > 0 ? " and " : string.Empty;
+                var whereScore = ratings.Score > 0 ? $"pm.Score = {ratings.Score}" : string.Empty;
+                var andScoreAndSub = !string.IsNullOrWhiteSpace(ratings.SubCategory) && ratings.Score > 0 ? " and " : string.Empty;
+                var whereSubCategory = !string.IsNullOrWhiteSpace(ratings.SubCategory) ? $"mr.SubCategory = '{ratings.SubCategory}'" : string.Empty;
+
+                return $"({whereCategory}{andCatAndScore}{whereScore}{andScoreAndSub}{whereSubCategory})";
             }
 
             return string.Empty;

--- a/src/API/LeadershipProfileAPI/Data/Models/ListItem/ListItemSubCategory.cs
+++ b/src/API/LeadershipProfileAPI/Data/Models/ListItem/ListItemSubCategory.cs
@@ -2,7 +2,8 @@
 {
     public class ListItemSubCategory
     {
-        public string Text { get; set; }
-        public int Value { get; set; }
+        public int CategoryId { get; set; }
+        public string Category { get; set; }
+        public string SubCategory { get; set; }
     }
 }


### PR DESCRIPTION
The view that was being used didn't exist so the vw_ListAllCategoriesSubCategories was used.  The columns on this view also did not match the Text & Value convention of the other web component views so the model was adjusted to accommodate it rather than adjusting the view. The changes to the model resulted in a renaming of the class to SubCategoryItem as there was now a property called SubCategory. 

There were errors being thrown on the Ratings column so the order was fixed so it would cast the column first and then if it was null it would use the default value of 0.0.